### PR TITLE
use email/password

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ With Bring! your list will be available on Android, iOs and via Web Access.
 
 ## Setup
 This skill for SNIPS takes two secret parameters:
-The first one is your unique user ID, the second one is the unique ID of your shopping list.
-You can get these here after you fill in your credentials: https://api.getbring.com/rest/bringlists?email=~mail-adress~&password=~password~
+The first one is the email adress and the second one is the password of your bring shopping list.
 
 ## Usage
 ### Deutsch:

--- a/action-Philipp.bring_shopping.py
+++ b/action-Philipp.bring_shopping.py
@@ -48,7 +48,10 @@ def subscribe_intent_callback(client, userdata, msg):
         garuda.publish_end_session(payload["sessionId"], random.choice(i18n.NODEL_ALL))
       
 def get_bring(conf):
-    return BringApi(conf['secret']['uuid'],conf['secret']['bringlistuuid'])
+    try:
+        return BringApi(conf['secret']['email'],conf['secret']['password'], use_login=True)
+    except BringApi.AuthentificationFailed as e:
+        print(str(e))
 
 def delete_complete_list(conf):
     bring = get_bring(conf)

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,3 @@
 [secret]
-uuid=xxx
-bringlistuuid=xxx
+email=xxx
+password=xxx

--- a/config.ini.default
+++ b/config.ini.default
@@ -1,3 +1,3 @@
 [secret]
-uuid=uuid
-bringlistuuid=bringlistuuid
+email=email
+password=password


### PR DESCRIPTION
the user does not has to create his uuid himself this way. The try/except is added because the library no longer prints an error message when the authentification fails but throws an exception